### PR TITLE
Modify content security policy to allow self and data URI font-src

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -15,5 +15,11 @@
 *
 */
 
+// Modify content security policy to allow self and data URI font-src
+$policy = new OCP\AppFramework\Http\EmptyContentSecurityPolicy();
+$policy->addAllowedFontDomain('self');
+$policy->addAllowedFontDomain('data:');
+\OC::$server->getContentSecurityPolicyManager()->addDefaultPolicy($policy);
+
 OCP\Util::addStyle( 'files_videoplayer', 'style' );
 OCP\Util::addscript( 'files_videoplayer', 'viewer');


### PR DESCRIPTION
Having issues with content security policy not allowing Video.JS to load it's font for player controls. Allowing data: sources corrects this.