### PR TITLE
So.. CSP doesn't exist in the AppFramework for OC8.2

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -16,10 +16,12 @@
 */
 
 // Modify content security policy to allow self and data URI font-src
-$policy = new OCP\AppFramework\Http\EmptyContentSecurityPolicy();
-$policy->addAllowedFontDomain('self');
-$policy->addAllowedFontDomain('data:');
-\OC::$server->getContentSecurityPolicyManager()->addDefaultPolicy($policy);
+if (\OCP\Util::getVersion()[0] >= 10) {
+  $policy = new OCP\AppFramework\Http\EmptyContentSecurityPolicy();
+  $policy->addAllowedFontDomain('self');
+  $policy->addAllowedFontDomain('data:');
+  \OC::$server->getContentSecurityPolicyManager()->addDefaultPolicy($policy);
+}
 
 OCP\Util::addStyle( 'files_videoplayer', 'style' );
 OCP\Util::addscript( 'files_videoplayer', 'viewer');


### PR DESCRIPTION
Content Security Policy framework doesn't exist in Owncloud 8.2.11, so only load it for Owncloud 10